### PR TITLE
async: expose filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 Reads the closest package.json file and parses its JSON.
 
 ```js
-require('read-closest-package')(function(err, data) {
+require('read-closest-package')(function(err, data, filename) {
   console.log(data.version)
   console.log(data.description)
+  console.log(filename)
 })
 ```
 
@@ -27,7 +28,8 @@ if (pkg)
 
 #### `closest([opt], cb)`
 
-Looks for the closest package and calls the callback `cb` with `(err, data)`.
+Looks for the closest package and calls the callback `cb` with `(err, data,
+filename)`.
 
 - `cwd` the working directory to search up from for the package.json (defaults to `process.cwd()`)
 - `filter` a filter passed to [closest-package](https://github.com/hughsk/closest-package/)

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 var closest = require('closest-package')
 var read = require('load-json-file')
 
-var truthy = function () { return true }
-
 module.exports = function (opt, cb) {
   if (typeof opt === 'function') {
     cb = opt
@@ -12,8 +10,15 @@ module.exports = function (opt, cb) {
     throw new TypeError('must specify function as second argument')
   }
 
+  var filename = null
+  var truthy = function (json, path) {
+    filename = path
+    return true
+  }
+
   var cwd = opt.cwd || process.cwd()
   var filter = opt.filter || truthy
+
   closest(cwd, filter, function (err, file) {
     if (err || !file) {
       return process.nextTick(function () {
@@ -21,7 +26,7 @@ module.exports = function (opt, cb) {
       })
     }
     read(file).then(function (json) {
-      cb(null, json)
+      cb(null, json, filename)
     }, cb)
   })
 }
@@ -29,7 +34,7 @@ module.exports = function (opt, cb) {
 module.exports.sync = function (opt) {
   opt = opt || {}
   var cwd = opt.cwd || process.cwd()
-  var filter = opt.filter || truthy
+  var filter = opt.filter || function () { return true }
   var result = closest.sync(cwd, filter)
   if (result) {
     return read.sync(result)

--- a/test.js
+++ b/test.js
@@ -3,10 +3,12 @@ var test = require('tape')
 var expected = require('./package.json')
 
 test('reads the closest package.json file', function (t) {
-  t.plan(1)
-  read(function (err, data) {
+  t.plan(3)
+  read(function (err, data, file) {
     if (err) t.fail(err)
     t.deepEqual(data, expected, 'matches this package.json')
+    t.equal(typeof file, 'string')
+    t.ok(/package\.json$/.test(file))
   })
 })
 


### PR DESCRIPTION
Exposes `filename` in the done callback; useful for finding the right path to write modified `package.json` files to (as we're doing in `quick-stub` / `initialize-cli`). Thanks!
